### PR TITLE
Extract abstract classes to their own files for proper PSR-4 support

### DIFF
--- a/src/Format.php
+++ b/src/Format.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace mastani\GoogleStaticMap;
+
+abstract class Format
+{
+    const JPG = 'jpg';
+    const PNG = 'png';
+    const GIF = 'gif';
+}

--- a/src/GoogleStaticMap.php
+++ b/src/GoogleStaticMap.php
@@ -294,22 +294,3 @@ class GoogleStaticMap {
         return $randomString;
     }
 }
-
-abstract class MapType {
-    const RoadMap = 'roadmap';
-    const Terrain = 'terrain';
-    const Satellite = 'satellite';
-    const Hybrid = 'hybrid';
-}
-
-abstract class Format {
-    const JPG = 'jpg';
-    const PNG = 'png';
-    const GIF = 'gif';
-}
-
-abstract class Size {
-    const Small = 'tiny';
-    const Medium = 'small';
-    const Large = 'mid';
-}

--- a/src/MapType.php
+++ b/src/MapType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace mastani\GoogleStaticMap;
+
+abstract class MapType
+{
+    const RoadMap = 'roadmap';
+    const Terrain = 'terrain';
+    const Satellite = 'satellite';
+    const Hybrid = 'hybrid';
+}

--- a/src/Size.php
+++ b/src/Size.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace mastani\GoogleStaticMap;
+
+abstract class Size
+{
+    const Small = 'tiny';
+    const Medium = 'small';
+    const Large = 'mid';
+}


### PR DESCRIPTION
As of Composer 2.x, the abstract classes that currently reside within the main `GoogleStaticMap.php` file will no longer be loaded.

This PR simply extracts the abstract classes to their own files so that Composer doesn't skip over them.
